### PR TITLE
Fix pkg_resources.VersionConflict error

### DIFF
--- a/news/10.bugfix
+++ b/news/10.bugfix
@@ -1,0 +1,2 @@
+Fix pkg_resources.VersionConflict error when downgrading an already installed
+dependency.

--- a/src/pip_deepfreeze/list_depends_script.py
+++ b/src/pip_deepfreeze/list_depends_script.py
@@ -21,7 +21,7 @@ def main(distname):
             return
         seen.add(seen_key)
         try:
-            dist = pkg_resources.get_distribution(req)
+            dist = pkg_resources.get_distribution(req.key)
         except pkg_resources.DistributionNotFound:
             return
         else:


### PR DESCRIPTION
This happens when downgrading an already installed dependency,
because setuptools prepare_metadata_for_build_wheel update
the requirements list in .egg-info.

fixes #10 