### PR TITLE
Improve sanity check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -25,7 +25,7 @@ repos:
       - id: flake8
         additional_dependencies: ["flake8-bugbear==20.1.4"]
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.0.9
+    rev: v5.3.2
     hooks:
       - id: isort
   - repo: https://github.com/myint/docformatter
@@ -34,6 +34,6 @@ repos:
       - id: docformatter
         args: ["--in-place", "--wrap-summaries=88"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.0
+    rev: v2.7.2
     hooks:
       - id: pyupgrade

--- a/news/38.feature
+++ b/news/38.feature
@@ -1,0 +1,3 @@
+Refuse to start if the target python is not running in a virtualenv,
+or if the virtualenv includes system site packages. This would be dangerous,
+risking removing or updating system packages.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "packaging>=20.4",
         "toml",
         "typer[all]",
-        'typing-extensions ; python_version<"3.8"',  # for Protocol
+        'typing-extensions ; python_version<"3.8"',  # for Protocol, TypedDict
     ],
     extras_require={
         "test": ["pytest", "pytest-cov", "pytest-xdist", "virtualenv"],
@@ -49,8 +49,8 @@ setup(
         ]
     },
     project_urls={
-        "Bug Reports": "https://github.com/sbidoul/pip-deepfreeze/issues",
         "Source": "https://github.com/sbidoul/pip-deepfreeze/",
+        "Bug Reports": "https://github.com/sbidoul/pip-deepfreeze/issues",
         "Changelog": (
             "https://github.com/sbidoul/pip-deepfreeze/blob/master/HISTORY.rst"
         ),

--- a/src/pip_deepfreeze/compat.py
+++ b/src/pip_deepfreeze/compat.py
@@ -2,7 +2,7 @@ import shlex
 import sys
 from typing import TYPE_CHECKING, Iterable, NewType
 
-__all__ = ["shlex_join", "resource_as_file", "resource_files", "Protocol"]
+__all__ = ["shlex_join", "resource_as_file", "resource_files", "Protocol", "TypedDict"]
 
 if sys.version_info >= (3, 8):
     from shlex import join as shlex_join
@@ -13,9 +13,9 @@ else:
 
 
 if sys.version_info >= (3, 8):
-    from typing import Protocol
+    from typing import Protocol, TypedDict
 else:
-    from typing_extensions import Protocol
+    from typing_extensions import Protocol, TypedDict
 
 
 if sys.version_info >= (3, 9):

--- a/src/pip_deepfreeze/env_info_json.py
+++ b/src/pip_deepfreeze/env_info_json.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# type: ignore
+"""Collect information about the python envionment.
+
+Prints a json dictionary with the following keys:
+- has_pkg_resources: bool
+- has_importlib_metadata: bool
+- pip_version: str
+- setuptools_version: str
+- wheel_version: str
+- in_virtualenv: bool
+
+This script must be python 2 compatible.
+"""
+import json
+import os
+import sys
+
+try:
+    from typing import Dict, Optional, Union
+except ImportError:
+    pass
+
+
+def _check_pkg_resources():
+    # type: () -> bool
+    try:
+        import pkg_resources  # noqa
+    except ImportError:
+        return False
+    else:
+        return True
+
+
+def _check_importlib_metadata():
+    # type: () -> bool
+    if sys.version_info >= (3, 8):
+        return True
+    else:
+        try:
+            import importlib_metadata  # noqa
+        except ImportError:
+            return False
+        else:
+            return True
+
+
+def _get_version_importlib_metadata(dist_name):
+    # type: (str) -> Optional[str]
+    if sys.version_info >= (3, 8):
+        from importlib import metadata as importlib_metadata
+    else:
+        import importlib_metadata
+
+    try:
+        return importlib_metadata.version(dist_name)
+    except importlib_metadata.PackageNotFoundError:
+        return None
+
+
+def _get_version_pkg_resources(dist_name):
+    # type: (str) -> Optional[str]
+    import pkg_resources
+
+    try:
+        return pkg_resources.get_distribution(dist_name).version
+    except pkg_resources.DistributionNotFound:
+        return None
+
+
+def _find_pyvenv_cfg_path():
+    # type: () -> Optional[str]
+    pyvenv_cfg_path = os.path.join(os.path.dirname(sys.executable), "pyvenv.cfg")
+    if os.path.isfile(pyvenv_cfg_path):
+        return pyvenv_cfg_path
+    pyvenv_cfg_path = os.path.join(os.path.dirname(sys.executable), "..", "pyvenv.cfg")
+    if os.path.isfile(pyvenv_cfg_path):
+        return pyvenv_cfg_path
+    return None
+
+
+def main():
+    # type: () -> None
+    result = {}  # type: Dict[str, Union[Optional[str], bool]]
+    pyvenv_cfg_path = _find_pyvenv_cfg_path()
+    result["in_virtualenv"] = bool(pyvenv_cfg_path)
+    result["has_pkg_resources"] = _check_pkg_resources()
+    result["has_importlib_metadata"] = _check_importlib_metadata()
+    _get_version = None
+    if result["has_importlib_metadata"]:
+        _get_version = _get_version_importlib_metadata
+    elif result["has_pkg_resources"]:
+        _get_version = _get_version_pkg_resources
+    if _get_version:
+        result["pip_version"] = _get_version("pip")
+        result["setuptools_version"] = _get_version("setuptools")
+        result["wheel_version"] = _get_version("wheel")
+    json.dump(result, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pip_deepfreeze/sanity.py
+++ b/src/pip_deepfreeze/sanity.py
@@ -10,6 +10,7 @@ EnvInfo = TypedDict(
     "EnvInfo",
     {
         "in_virtualenv": bool,
+        "include_system_site_packages": bool,
         "has_pkg_resources": bool,
         "has_importlib_metadata": bool,
         "pip_version": Optional[str],
@@ -32,6 +33,12 @@ def check_env(python: str) -> bool:
     env_info = _get_env_info(python)
     if not env_info.get("in_virtualenv"):
         log_error(f"{python} is not in a virtualenv, refusing to start.")
+        return False
+    if env_info.get("include_system_site_packages"):
+        log_error(
+            f"{python} is in a virtualenv that includes system site packages, "
+            f"refusing to start."
+        )
         return False
     if not env_info.get("has_pkg_resources"):
         setuptools_install_cmd = shlex_join(

--- a/src/pip_deepfreeze/sanity.py
+++ b/src/pip_deepfreeze/sanity.py
@@ -1,9 +1,9 @@
 import json
-from typing import Optional, TypedDict, cast
+from typing import Optional, cast
 
 from packaging.version import Version
 
-from .compat import resource_as_file, resource_files
+from .compat import TypedDict, resource_as_file, resource_files
 from .utils import check_output, log_error, log_warning, shlex_join
 
 EnvInfo = TypedDict(

--- a/src/pip_deepfreeze/sanity.py
+++ b/src/pip_deepfreeze/sanity.py
@@ -25,8 +25,8 @@ def _get_env_info(python: str) -> EnvInfo:
         resource_files("pip_deepfreeze").joinpath(  # type: ignore
             "env_info_json.py"
         )
-    ) as pip_list_json:
-        return cast(EnvInfo, json.loads(check_output([python, str(pip_list_json)])))
+    ) as env_info_json:
+        return cast(EnvInfo, json.loads(check_output([python, str(env_info_json)])))
 
 
 def check_env(python: str) -> bool:

--- a/src/pip_deepfreeze/sanity.py
+++ b/src/pip_deepfreeze/sanity.py
@@ -1,78 +1,65 @@
-import subprocess
-from typing import Optional
+import json
+from typing import Optional, TypedDict, cast
 
-from packaging.version import InvalidVersion, Version
+from packaging.version import Version
 
-from .utils import log_error, log_warning, shlex_join
+from .compat import resource_as_file, resource_files
+from .utils import check_output, log_error, log_warning, shlex_join
+
+EnvInfo = TypedDict(
+    "EnvInfo",
+    {
+        "in_virtualenv": bool,
+        "has_pkg_resources": bool,
+        "has_importlib_metadata": bool,
+        "pip_version": Optional[str],
+        "setuptools_version": Optional[str],
+        "wheel_version": Optional[str],
+    },
+)
 
 
-def _parse_pip_version(version_line: str) -> Optional[Version]:
-    try:
-        version_chunks = version_line.split()
-        if len(version_chunks) < 2:
-            raise InvalidVersion()
-        return Version(version_chunks[1])
-    except InvalidVersion:
-        log_warning(f"Could not detect pip version in pip output: {version_line!r}.")
-        return None
-
-
-def _check_pip(python: str) -> bool:
-    try:
-        version_line = subprocess.check_output(
-            [python, "-m", "pip", "--version"],
-            universal_newlines=True,
-            stderr=subprocess.STDOUT,
+def _get_env_info(python: str) -> EnvInfo:
+    with resource_as_file(
+        resource_files("pip_deepfreeze").joinpath(  # type: ignore
+            "env_info_json.py"
         )
-    except subprocess.CalledProcessError:
-        log_error(f"pip is not available to {python}. Please install it.")
+    ) as pip_list_json:
+        return cast(EnvInfo, json.loads(check_output([python, str(pip_list_json)])))
+
+
+def check_env(python: str) -> bool:
+    env_info = _get_env_info(python)
+    if not env_info.get("in_virtualenv"):
+        log_error(f"{python} is not in a virtualenv, refusing to start.")
         return False
-    else:
-        pip_version = _parse_pip_version(version_line)
-        if pip_version and pip_version < Version("20.1"):
-            install_cmd = shlex_join([python, "-m", "pip", "install", "pip>=20.1"])
-            log_warning(
-                f"pip-deepfreeze works best with pip>=20.1, "
-                f"in particular if you use direct URL references. "
-                f"You can install it with {install_cmd}."
-            )
-        return True
-
-
-def _check_pkg_resources(python: str) -> bool:
-    try:
-        subprocess.check_output(
-            [python, "-c", "import pkg_resources"], stderr=subprocess.STDOUT,
+    if not env_info.get("has_pkg_resources"):
+        setuptools_install_cmd = shlex_join(
+            [python, "-m", "pip", "install", "setuptools"]
         )
-    except subprocess.CalledProcessError:
-        install_cmd = shlex_join([python, "-m", "pip", "install", "setuptools"])
         log_error(
             f"pkg_resources is not available to {python}. It is currently "
-            f"required by pip-deepfreeze. You can install it with {install_cmd}."
+            f"required by pip-deepfreeze. "
+            f"You can install it with {setuptools_install_cmd}."
         )
         return False
-    else:
-        return True
-
-
-def _check_wheel(python: str) -> bool:
-    try:
-        subprocess.check_output(
-            [python, "-c", "import wheel"], stderr=subprocess.STDOUT,
+    pip_version = env_info.get("pip_version")
+    if not pip_version:
+        log_error(f"pip is not available to {python}. Please install it.")
+        return False
+    if Version(pip_version) < Version("20.1"):
+        pip_install_cmd = shlex_join([python, "-m", "pip", "install", "pip>=20.1"])
+        log_warning(
+            f"pip-deepfreeze works best with pip>=20.1, "
+            f"in particular if you use direct URL references. "
+            f"You can upgrade pip it with {pip_install_cmd}."
         )
-    except subprocess.CalledProcessError:
-        install_cmd = shlex_join([python, "-m", "pip", "install", "wheel"])
+    if not env_info.get("wheel_version"):
+        wheel_install_cmd = shlex_join([python, "-m", "pip", "install", "wheel"])
         log_warning(
             f"wheel is not available to {python}. "
             f"pip currently works best when the wheel package is installed, "
             f"in particular if you use direct URL references. "
-            f"You can install it with {install_cmd}."
+            f"You can install it with {wheel_install_cmd}."
         )
     return True
-
-
-def check_env(python: str) -> bool:
-    pip_ok = _check_pip(python)
-    pkg_resources_ok = _check_pkg_resources(python)
-    wheel_ok = _check_wheel(python)
-    return pip_ok and pkg_resources_ok and wheel_ok

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,20 @@ def virtualenv_python(tmp_path):
     return str(python)
 
 
+@pytest.fixture
+def virtualenv_python_with_system_site_packages(tmp_path):
+    """Return a python executable path within an isolated virtualenv."""
+    venv = tmp_path / "venv"
+    subprocess.check_call(
+        [sys.executable, "-m", "virtualenv", str(venv), "--system-site-packages"]
+    )
+    if os.name == "nt":
+        python = venv / "Scripts" / "python.exe"
+    else:
+        python = venv / "bin" / "python"
+    return str(python)
+
+
 @pytest.fixture(scope="session")
 def testpkgs(tmp_path_factory):
     """Create test wheels and return the temp dir where they are stored."""

--- a/tests/test_env_info_json.py
+++ b/tests/test_env_info_json.py
@@ -1,0 +1,17 @@
+import json
+import os
+import subprocess
+
+# /!\ this test file must be python 2 compatible /!\
+ENV_INFO_JSON = os.path.join(
+    os.path.dirname(__file__), "..", "src", "pip_deepfreeze", "env_info_json.py"
+)
+
+
+def test_env_info_json(virtualenv_python):
+    """Basic check, more elaborate tests are in test_sanity.py."""
+    env_info_json = subprocess.check_output(
+        [virtualenv_python, ENV_INFO_JSON], universal_newlines=True,
+    )
+    env_info = json.loads(env_info_json)
+    assert "in_virtualenv" in env_info

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,4 +1,5 @@
 import subprocess
+from pathlib import Path
 
 from typer.testing import CliRunner
 
@@ -48,3 +49,18 @@ def test_sanity_main(virtualenv_python):
     result = runner.invoke(app, ["--python", virtualenv_python, "tree"])
     assert result.exit_code != 0
     assert "pip not available", result.stderr
+
+
+def test_sanity_venv_no_pyvenv_cfg(virtualenv_python, capsys):
+    (Path(virtualenv_python).parent.parent / "pyvenv.cfg").unlink()
+    assert not check_env(virtualenv_python)
+    captured = capsys.readouterr()
+    assert "is not in a virtualenv", captured.stderr
+
+
+def test_sanity_venv_system_site_packages(
+    virtualenv_python_with_system_site_packages, capsys
+):
+    assert not check_env(virtualenv_python_with_system_site_packages)
+    captured = capsys.readouterr()
+    assert "virtualenv that includes system site packages", captured.stderr

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,7 +1,5 @@
 import subprocess
-import textwrap
 
-import pytest
 from typer.testing import CliRunner
 
 from pip_deepfreeze.__main__ import app
@@ -22,33 +20,6 @@ def test_sanity_pip_version(virtualenv_python, capsys):
     assert check_env(virtualenv_python)
     captured = capsys.readouterr()
     assert "works best with pip>=20.1" in captured.err
-
-
-@pytest.mark.parametrize("bad_pip_version_line", ["pip a ...", "pip"])
-def test_sanity_invalid_pip_version(
-    virtualenv_python, capsys, tmp_path, bad_pip_version_line
-):
-    assert check_env(virtualenv_python)
-    (tmp_path / "setup.py").write_text(
-        textwrap.dedent(
-            """\
-            from setuptools import setup
-
-            setup(
-                name="pip",
-                packages=["pip"],
-            )
-            """
-        )
-    )
-    (tmp_path / "pip").mkdir()
-    (tmp_path / "pip" / "__main__.py").write_text(f"print('{bad_pip_version_line}')")
-    subprocess.check_call(
-        [virtualenv_python, "-m", "pip", "install", "-q", str(tmp_path)]
-    )
-    assert check_env(virtualenv_python)
-    captured = capsys.readouterr()
-    assert "Could not detect pip version in" in captured.err
 
 
 def test_sanity_pkg_resources(virtualenv_python, capsys):

--- a/tox.ini
+++ b/tox.ini
@@ -16,13 +16,13 @@ commands =
   pytest -n auto --cov={toxinidir}/src/pip_deepfreeze --cov-branch --cov-report=html --cov-report=term {posargs}
 
 [testenv:py27]
-# run only pip_list_json tests on python 2
+# run only helper scripts tests on python 2
 skip_install = true
 deps =
   pytest
   virtualenv
 commands =
-  pytest -vv {toxinidir}/tests/test_pip_list_json.py
+  pytest -vv {toxinidir}/tests/test_pip_list_json.py {toxinidir}/tests/test_env_info_json.py
 
 [testenv:mypy]
 extras = mypy


### PR DESCRIPTION
- Delegate sanity checks to a subprocess running with the target python.
- Refuse to start if target python is not in a virtualenv.
- Refuse to start if virtualenv includes system site packages.

closes #38 
