### PR TITLE
Restore PEP 621 support

### DIFF
--- a/news/56.feature
+++ b/news/56.feature
@@ -1,0 +1,1 @@
+Now that PEP 621 is in provisional state, use it to detect the project name.

--- a/src/pip_deepfreeze/project_name.py
+++ b/src/pip_deepfreeze/project_name.py
@@ -25,7 +25,8 @@ def get_project_name(python: str, project_root: Path) -> NormalizedName:
     log_info("Getting project name..", nl=False)
     pyproject_toml = _load_pyproject_toml(project_root)
     name = (
-        get_project_name_from_setup_cfg(project_root, pyproject_toml)
+        get_project_name_from_pyproject_toml_pep621(pyproject_toml)
+        or get_project_name_from_setup_cfg(project_root, pyproject_toml)
         or get_project_name_from_pyproject_toml_flit(pyproject_toml)
         or get_project_name_from_pep517(python, project_root)
     )

--- a/tests/test_project_name.py
+++ b/tests/test_project_name.py
@@ -1,8 +1,6 @@
 import sys
 import textwrap
 
-import pytest
-
 from pip_deepfreeze.project_name import (
     _load_pyproject_toml,
     get_project_name,
@@ -77,7 +75,6 @@ def test_get_project_name_from_pyproject_toml_flit_no_module(tmp_path):
     assert not get_project_name_from_pyproject_toml_flit(_load_pyproject_toml(tmp_path))
 
 
-@pytest.mark.xfail(reason="pep621 is not adopted yet")
 def test_get_project_name_from_pyproject_toml_pep621(tmp_path):
     (tmp_path / "pyproject.toml").write_text(
         textwrap.dedent(
@@ -97,7 +94,6 @@ def test_get_project_name_from_pyproject_toml_pep621(tmp_path):
     assert get_project_name(sys.executable, tmp_path) == "theproject"
 
 
-@pytest.mark.xfail(reason="pep621 is not adopted yet")
 def test_get_project_name_from_pyproject_toml_pep621_no_project(tmp_path):
     (tmp_path / "pyproject.toml").write_text(
         textwrap.dedent(


### PR DESCRIPTION
Now that PEP 621 is in provisional state, use it to detect the project name.