### PR TITLE
Rename --extra short option from -e to -x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -348,7 +348,7 @@ pip-df sync
                                      Defaults to editable if the project supports
                                      it.
 
-     -e, --extras EXTRAS             Extras to install and freeze to
+     -x, --extras EXTRAS             Extras to install and freeze to
                                      requirements-{EXTRA}.txt.
 
      --uninstall-unneeded / --no-uninstall-unneeded
@@ -377,7 +377,7 @@ pip-df tree
      Print the installed dependencies of the project as a tree.
 
    Options:
-     -e, --extras EXTRAS  Extras of project to consider when looking for
+     -x, --extras EXTRAS  Extras of project to consider when looking for
                           dependencies.
 
      --help               Show this message and exit.

--- a/news/50.bugfix
+++ b/news/50.bugfix
@@ -1,1 +1,1 @@
-``pip-df sync -e`` now warns but otherwise ignores unknown extras.
+``pip-df sync --extras`` now warns but otherwise ignores unknown extras.

--- a/news/57.feature
+++ b/news/57.feature
@@ -1,0 +1,2 @@
+Rename ``--extra`` short option from ``-e`` to ``-x``, to avoid confusion with
+pip's ``-e`` which is for editables.

--- a/src/pip_deepfreeze/__main__.py
+++ b/src/pip_deepfreeze/__main__.py
@@ -45,7 +45,7 @@ def sync(
     extras: str = typer.Option(
         None,
         "--extras",
-        "-e",
+        "-x",
         metavar="EXTRAS",
         help="Extras to install and freeze to requirements-{EXTRA}.txt.",
     ),
@@ -106,7 +106,7 @@ def tree(
     extras: str = typer.Option(
         None,
         "--extras",
-        "-e",
+        "-x",
         metavar="EXTRAS",
         help="Extras of project to consider when looking for dependencies.",
     ),

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -77,7 +77,7 @@ def test_tree_extras(virtualenv_python, testpkgs, tmp_path):
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         app,
-        ["-p", virtualenv_python, "-r", tmp_path, "tree", "-e", "c"],
+        ["-p", virtualenv_python, "-r", tmp_path, "tree", "-x", "c"],
         obj=MainOptions(),
     )
     assert result.exit_code == 0


### PR DESCRIPTION
To avoid confusion with -e as editable.