### PR TITLE
Remove --no-use-pip-constraints option

### DIFF
--- a/news/60.removal
+++ b/news/60.removal
@@ -1,0 +1,3 @@
+Remove ``--no-use-pip-constraints`` option. Users should switch to a pip
+version that supports URL constraints, which is all of them for the legacy
+resolver, and 21.1+ for the new resolver.

--- a/src/pip_deepfreeze/__main__.py
+++ b/src/pip_deepfreeze/__main__.py
@@ -64,16 +64,6 @@ def sync(
             "If not specified, ask confirmation."
         ),
     ),
-    use_pip_constraints: bool = typer.Option(
-        True,
-        help=(
-            "Use pip --constraints instead of --requirements when passing "
-            "pinned dependencies and constraints to pip. This has advantages "
-            "such as marking only the project as REQUESTED, but may fail in "
-            "some circumstances such as when using direct URLs with the new "
-            "pip resolver."
-        ),
-    ),
 ) -> None:
     """Install/update the environment to match the project requirements.
 
@@ -96,7 +86,6 @@ def sync(
         extras=[canonicalize_name(extra) for extra in comma_split(extras)],
         uninstall_unneeded=uninstall_unneeded,
         project_root=ctx.obj.project_root,
-        use_pip_constraints=use_pip_constraints,
     )
 
 

--- a/src/pip_deepfreeze/pip.py
+++ b/src/pip_deepfreeze/pip.py
@@ -24,7 +24,6 @@ def pip_upgrade_project(
     project_root: Path,
     extras: Optional[Sequence[NormalizedName]] = None,
     editable: bool = True,
-    use_pip_constraints: bool = True,
 ) -> None:
     """Upgrade a project.
 
@@ -80,20 +79,9 @@ def pip_upgrade_project(
         log_info(f"Uninstalling dependencies to update: {to_uninstall_str}")
         pip_uninstall(python, to_uninstall)
     # 4. install project with constraints
-    # TODO Using -c here would break with the new pip resolver:
-    #      https://github.com/pypa/pip/issues/8253 and in some other
-    #      situations with the legacy resolver.
-    #      If we can't make pip handle direct URLs as constraints,
-    #      then the second best approach is to use -r here, and let
-    #      sync's --uninstall option remove what we don't need.
-    #      But the REQUESTED metadata will be incorrect.
-    if use_pip_constraints:
-        constraints_mode = "-c"
-    else:
-        constraints_mode = "-r"
     project_name = get_project_name(python, project_root)
     log_info(f"Installing/updating {project_name}")
-    cmd = [python, "-m", "pip", "install", constraints_mode, f"{constraints_filename}"]
+    cmd = [python, "-m", "pip", "install", "-c", f"{constraints_filename}"]
     if editable:
         cmd.append("-e")
     if extras:

--- a/src/pip_deepfreeze/sync.py
+++ b/src/pip_deepfreeze/sync.py
@@ -42,7 +42,6 @@ def sync(
     extras: List[NormalizedName],
     uninstall_unneeded: Optional[bool],
     project_root: Path,
-    use_pip_constraints: bool,
 ) -> None:
     project_name = get_project_name(python, project_root)
     project_name_with_extras = make_project_name_with_extras(project_name, extras)
@@ -71,7 +70,6 @@ def sync(
             project_root,
             editable=editable,
             extras=extras,
-            use_pip_constraints=use_pip_constraints,
         )
     finally:
         constraints_path.unlink()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,29 +12,13 @@ def virtualenv_python(tmp_path):
     """Return a python executable path within an isolated virtualenv, using a pip
     version that has the new resolver."""
     venv = tmp_path / "venv"
-    subprocess.check_call(
-        # TODO remove pip version pin
-        [sys.executable, "-m", "virtualenv", "--pip", "20.3.3", str(venv)]
-    )
+    subprocess.check_call([sys.executable, "-m", "virtualenv", str(venv)])
     if os.name == "nt":
         python = venv / "Scripts" / "python.exe"
     else:
         python = venv / "bin" / "python"
-    return str(python)
-
-
-@pytest.fixture
-def virtualenv_python_legacy_resolver(tmp_path):
-    """Return a python executable path within an isolated virtualenv, using a pip
-    version that has the legacy resolver."""
-    venv = tmp_path / "venv"
-    subprocess.check_call(
-        [sys.executable, "-m", "virtualenv", "--pip", "20.2.4", str(venv)]
-    )
-    if os.name == "nt":
-        python = venv / "Scripts" / "python.exe"
-    else:
-        python = venv / "bin" / "python"
+    # use latest pip
+    subprocess.check_call([str(python), "-m", "pip", "install", "-U", "pip"])
     return str(python)
 
 

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -263,16 +263,12 @@ def test_pip_upgrade_constraint_not_a_dep(virtualenv_python, testpkgs, tmp_path)
         )
     )
     constraints.write_text(f"--no-index\n--find-links {testpkgs}\npkgc==0.0.1")
-    pip_upgrade_project(
-        virtualenv_python, constraints, project_root=tmp_path, use_pip_constraints=True
-    )
+    pip_upgrade_project(virtualenv_python, constraints, project_root=tmp_path)
     assert list(_freeze_filter(pip_freeze(virtualenv_python))) == []
 
 
-def test_pip_upgrade_vcs_url(virtualenv_python_legacy_resolver, tmp_path):
+def test_pip_upgrade_vcs_url(virtualenv_python, tmp_path):
     """Test upgrading a VCS URL."""
-    # TODO use the legacy resolver until pip supports URL constraints again
-    #      (https://github.com/pypa/pip/issues/8253)
     constraints = tmp_path / "requirements.txt.df"
     (tmp_path / "setup.py").write_text(
         textwrap.dedent(
@@ -288,19 +284,15 @@ def test_pip_upgrade_vcs_url(virtualenv_python_legacy_resolver, tmp_path):
     )
     # install tag 0.10.0
     constraints.write_text("--no-index\ntoml @ git+https://github.com/uiri/toml@0.10.0")
-    pip_upgrade_project(
-        virtualenv_python_legacy_resolver, constraints, project_root=tmp_path
-    )
-    assert list(_freeze_filter(pip_freeze(virtualenv_python_legacy_resolver))) == [
+    pip_upgrade_project(virtualenv_python, constraints, project_root=tmp_path)
+    assert list(_freeze_filter(pip_freeze(virtualenv_python))) == [
         "toml @ git+https://github.com/uiri/toml"
         "@4935f616ef78c35a968b2473e806d7049eba9af1"
     ]
     # upgrade to tag 0.10.1
     constraints.write_text("toml @ git+https://github.com/uiri/toml@0.10.1")
-    pip_upgrade_project(
-        virtualenv_python_legacy_resolver, constraints, project_root=tmp_path
-    )
-    assert list(_freeze_filter(pip_freeze(virtualenv_python_legacy_resolver))) == [
+    pip_upgrade_project(virtualenv_python, constraints, project_root=tmp_path)
+    assert list(_freeze_filter(pip_freeze(virtualenv_python))) == [
         "toml @ git+https://github.com/uiri/toml"
         "@a86fc1fbd650a19eba313c3f642c9e2c679dc8d6"
     ]

--- a/tests/test_pip_list_json.py
+++ b/tests/test_pip_list_json.py
@@ -55,18 +55,11 @@ PIP_LIST_JSON = os.path.join(
         )
     ],
 )
-def test_pip_list_json(to_install, expected, virtualenv_python, testpkgs):
-    subprocess.check_call(
-        [
-            virtualenv_python,
-            "-m",
-            "pip",
-            "install",
-            "pytest-cov",  # pytest-cov needed for subprocess coverage to work
-        ]
-    )
+def test_pip_list_json(
+    to_install, expected, virtualenv_python_with_pytest_cov, testpkgs
+):
     install_cmd = [
-        virtualenv_python,
+        virtualenv_python_with_pytest_cov,
         "-m",
         "pip",
         "install",
@@ -79,7 +72,7 @@ def test_pip_list_json(to_install, expected, virtualenv_python, testpkgs):
         install_cmd += ["--use-feature", "2020-resolver"]
     subprocess.check_call(install_cmd)
     depends_str = subprocess.check_output(
-        [virtualenv_python, PIP_LIST_JSON],
+        [virtualenv_python_with_pytest_cov, PIP_LIST_JSON],
         universal_newlines=True,
     )
     depends_list = json.loads(depends_str)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -216,7 +216,6 @@ def test_sync_project_root(virtualenv_python, editable_foobar_path):
         extras=[],
         uninstall_unneeded=False,
         project_root=editable_foobar_path,
-        use_pip_constraints=True,
     )
     assert (editable_foobar_path / "requirements.txt").exists()
 
@@ -243,7 +242,6 @@ def test_sync_uninstall(virtualenv_python, tmp_path, testpkgs):
         extras=[],
         uninstall_unneeded=False,
         project_root=tmp_path,
-        use_pip_constraints=True,
     )
     assert "pkga==" in "\n".join(pip_freeze(virtualenv_python))
     # remove dependency on pkga
@@ -265,7 +263,6 @@ def test_sync_uninstall(virtualenv_python, tmp_path, testpkgs):
         extras=[],
         uninstall_unneeded=False,
         project_root=tmp_path,
-        use_pip_constraints=True,
     )
     assert "pkga==" in "\n".join(pip_freeze(virtualenv_python))
     # sync with uninstall=True, pkga removed
@@ -277,7 +274,6 @@ def test_sync_uninstall(virtualenv_python, tmp_path, testpkgs):
         extras=[],
         uninstall_unneeded=True,
         project_root=tmp_path,
-        use_pip_constraints=True,
     )
     assert "pkga==" not in "\n".join(pip_freeze(virtualenv_python))
 
@@ -327,7 +323,6 @@ def test_sync_update_new_dep(virtualenv_python, testpkgs, tmp_path):
         extras=[],
         uninstall_unneeded=False,
         project_root=tmp_path,
-        use_pip_constraints=True,
     )
     assert "pkgc==0.0.3" in "\n".join(pip_freeze(virtualenv_python))
 
@@ -377,7 +372,6 @@ def test_sync_update_all_new_dep(virtualenv_python, testpkgs, tmp_path):
         extras=[],
         uninstall_unneeded=False,
         project_root=tmp_path,
-        use_pip_constraints=True,
     )
     assert "pkgc==0.0.3" in "\n".join(pip_freeze(virtualenv_python))
 
@@ -414,7 +408,6 @@ def test_sync_extras(virtualenv_python, testpkgs, tmp_path):
         extras=["c"],
         uninstall_unneeded=False,
         project_root=tmp_path,
-        use_pip_constraints=True,
     )
     assert {"pkga", "pkgb", "pkgc"}.issubset(pip_list(virtualenv_python))
     requirements_txt = (tmp_path / "requirements.txt").read_text()
@@ -434,7 +427,6 @@ def test_sync_extras(virtualenv_python, testpkgs, tmp_path):
         extras=["c"],
         uninstall_unneeded=False,
         project_root=tmp_path,
-        use_pip_constraints=True,
     )
     assert {"pkga", "pkgb", "pkgc"}.issubset(pip_list(virtualenv_python))
     requirements_txt = (tmp_path / "requirements.txt").read_text()


### PR DESCRIPTION
Users should switch to a pip version that supports URL as constraints (it was only unsupported in pip 20.3 and 21.0 with the new resolver).