### PR TITLE
Editable mode is now mandatory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Create and activate a virtual environment using your favorite tool. Run
 ``pip list`` to make sure ``pip``, ``setuptools`` and ``wheel`` are installed
 in the virtualenv.
 
-To install your project (in editable mode if supported) in the active virtual
+To install your project in editable mode in the active virtual
 environment, go to your project root directory and run:
 
 .. code:: console
@@ -343,10 +343,6 @@ pip-df sync
      --update-all                    Upgrade (or downgrade) all dependencies of
                                      your application to the latest allowed
                                      version.
-
-     --editable / --no-editable      Install the project in editable mode.
-                                     Defaults to editable if the project supports
-                                     it.
 
      -x, --extras EXTRAS             Extras to install and freeze to
                                      requirements-{EXTRA}.txt.

--- a/news/65.removal
+++ b/news/65.removal
@@ -1,0 +1,4 @@
+An editable installation of the project is now always done by pip-deepfreeze. The
+`--editable` option is removed as well as the attempt to detect if the project is
+editable. This allows correct support for projects that support PEP 660 and do not have
+a `setup.py`.

--- a/src/pip_deepfreeze/__main__.py
+++ b/src/pip_deepfreeze/__main__.py
@@ -1,11 +1,9 @@
 import shutil
 from pathlib import Path
-from typing import Optional
 
 import typer
 from packaging.utils import canonicalize_name
 
-from .detect import supports_editable
 from .sanity import check_env
 from .sync import sync as sync_operation
 from .tree import tree as tree_operation
@@ -49,14 +47,6 @@ def sync(
         metavar="EXTRAS",
         help="Extras to install and freeze to requirements-{EXTRA}.txt.",
     ),
-    editable: Optional[bool] = typer.Option(
-        None,
-        help=(
-            "Install the project in editable mode. "
-            "Defaults to editable if the project supports it."
-        ),
-        show_default=False,
-    ),
     uninstall_unneeded: bool = typer.Option(
         None,
         help=(
@@ -73,16 +63,10 @@ def sync(
     update of dependencies to to the latest version that matches
     constraints. Optionally uninstall unneeded dependencies.
     """
-    if editable is None:
-        editable = supports_editable()
-    elif editable and not supports_editable():
-        log_error("The project does not support editable installation.")
-        raise typer.Exit(1)
     sync_operation(
         ctx.obj.python,
         upgrade_all,
         comma_split(to_upgrade),
-        editable,
         extras=[canonicalize_name(extra) for extra in comma_split(extras)],
         uninstall_unneeded=uninstall_unneeded,
         project_root=ctx.obj.project_root,

--- a/src/pip_deepfreeze/detect.py
+++ b/src/pip_deepfreeze/detect.py
@@ -1,5 +1,0 @@
-from pathlib import Path
-
-
-def supports_editable(project_root: Path = Path(".")) -> bool:
-    return (project_root / "setup.py").is_file()

--- a/src/pip_deepfreeze/pip.py
+++ b/src/pip_deepfreeze/pip.py
@@ -23,7 +23,6 @@ def pip_upgrade_project(
     constraints_filename: Path,
     project_root: Path,
     extras: Optional[Sequence[NormalizedName]] = None,
-    editable: bool = True,
 ) -> None:
     """Upgrade a project.
 
@@ -82,8 +81,7 @@ def pip_upgrade_project(
     project_name = get_project_name(python, project_root)
     log_info(f"Installing/updating {project_name}")
     cmd = [python, "-m", "pip", "install", "-c", f"{constraints_filename}"]
-    if editable:
-        cmd.append("-e")
+    cmd.append("-e")
     if extras:
         extras_str = ",".join(extras)
         cmd.append(f"{project_root}[{extras_str}]")

--- a/src/pip_deepfreeze/sync.py
+++ b/src/pip_deepfreeze/sync.py
@@ -38,7 +38,6 @@ def sync(
     python: str,
     upgrade_all: bool,
     to_upgrade: List[str],
-    editable: bool,
     extras: List[NormalizedName],
     uninstall_unneeded: Optional[bool],
     project_root: Path,
@@ -68,7 +67,6 @@ def sync(
             python,
             constraints_path,
             project_root,
-            editable=editable,
             extras=extras,
         )
     finally:

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,7 +1,0 @@
-from pip_deepfreeze.detect import supports_editable
-
-
-def test_supports_editable(tmp_path):
-    assert not supports_editable(tmp_path)
-    (tmp_path / "setup.py").touch()
-    assert supports_editable(tmp_path)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -77,78 +77,6 @@ def test_python_not_found(tmp_path):
 
 
 @pytest.fixture
-def not_editable_foobar_path(tmp_path):
-    (tmp_path / "pyproject.toml").write_text(
-        textwrap.dedent(
-            """
-            [build-system]
-            requires = ["flit_core >=2,<3"]
-            build-backend = "flit_core.buildapi"
-
-            [tool.flit.metadata]
-            module = "foobar"
-            author = "Toto"
-            """
-        )
-    )
-    (tmp_path / "foobar.py").write_text(
-        textwrap.dedent(
-            """
-            '''This is foobar'''
-            __version__ = '0.0.1'
-            """
-        )
-    )
-    return tmp_path
-
-
-def test_not_editable_default_install(virtualenv_python, not_editable_foobar_path):
-    subprocess.check_call(
-        [sys.executable, "-m", "pip_deepfreeze", "--python", virtualenv_python, "sync"],
-        cwd=not_editable_foobar_path,
-    )
-    # installed not editable by default
-    assert "foobar @ file://" in "\n".join(pip_freeze(virtualenv_python))
-
-
-def test_not_editable_no_editable_install(virtualenv_python, not_editable_foobar_path):
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip_deepfreeze",
-            "--python",
-            virtualenv_python,
-            "sync",
-            "--no-editable",
-        ],
-        cwd=not_editable_foobar_path,
-    )
-    # installed no-editable as requested
-    assert "foobar @ file://" in "\n".join(pip_freeze(virtualenv_python))
-
-
-def test_not_editable_editable_install(virtualenv_python, not_editable_foobar_path):
-    # trying to force editable fails gracefully
-    with pytest.raises(subprocess.CalledProcessError) as e:
-        subprocess.check_output(
-            [
-                sys.executable,
-                "-m",
-                "pip_deepfreeze",
-                "--python",
-                virtualenv_python,
-                "sync",
-                "--editable",
-            ],
-            cwd=not_editable_foobar_path,
-            universal_newlines=True,
-            stderr=subprocess.STDOUT,
-        )
-    assert "The project does not support editable installation." in e.value.output
-
-
-@pytest.fixture
 def editable_foobar_path(tmp_path):
     setup_py = tmp_path / "setup.py"
     setup_py.write_text(
@@ -173,46 +101,11 @@ def test_editable_default_install(virtualenv_python, editable_foobar_path):
     assert "-e " in "\n".join(pip_freeze(virtualenv_python))
 
 
-def test_editable_editable_install(virtualenv_python, editable_foobar_path):
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip_deepfreeze",
-            "--python",
-            virtualenv_python,
-            "sync",
-            "--editable",
-        ],
-        cwd=editable_foobar_path,
-    )
-    # installed editable as requested
-    assert "-e " in "\n".join(pip_freeze(virtualenv_python))
-
-
-def test_editable_no_editable_install(virtualenv_python, editable_foobar_path):
-    # force no-editable
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip_deepfreeze",
-            "--python",
-            virtualenv_python,
-            "sync",
-            "--no-editable",
-        ],
-        cwd=editable_foobar_path,
-    )
-    assert "foobar @ file://" in "\n".join(pip_freeze(virtualenv_python))
-
-
 def test_sync_project_root(virtualenv_python, editable_foobar_path):
     sync(
         virtualenv_python,
         upgrade_all=False,
         to_upgrade=[],
-        editable=True,
         extras=[],
         uninstall_unneeded=False,
         project_root=editable_foobar_path,
@@ -238,7 +131,6 @@ def test_sync_uninstall(virtualenv_python, tmp_path, testpkgs):
         virtualenv_python,
         upgrade_all=False,
         to_upgrade=[],
-        editable=True,
         extras=[],
         uninstall_unneeded=False,
         project_root=tmp_path,
@@ -259,7 +151,6 @@ def test_sync_uninstall(virtualenv_python, tmp_path, testpkgs):
         virtualenv_python,
         upgrade_all=False,
         to_upgrade=[],
-        editable=True,
         extras=[],
         uninstall_unneeded=False,
         project_root=tmp_path,
@@ -270,7 +161,6 @@ def test_sync_uninstall(virtualenv_python, tmp_path, testpkgs):
         virtualenv_python,
         upgrade_all=False,
         to_upgrade=[],
-        editable=True,
         extras=[],
         uninstall_unneeded=True,
         project_root=tmp_path,
@@ -319,7 +209,6 @@ def test_sync_update_new_dep(virtualenv_python, testpkgs, tmp_path):
         virtualenv_python,
         upgrade_all=False,
         to_upgrade=["pkgc"],
-        editable=True,
         extras=[],
         uninstall_unneeded=False,
         project_root=tmp_path,
@@ -368,7 +257,6 @@ def test_sync_update_all_new_dep(virtualenv_python, testpkgs, tmp_path):
         virtualenv_python,
         upgrade_all=True,
         to_upgrade=[],
-        editable=True,
         extras=[],
         uninstall_unneeded=False,
         project_root=tmp_path,
@@ -404,7 +292,6 @@ def test_sync_extras(virtualenv_python, testpkgs, tmp_path):
         virtualenv_python,
         upgrade_all=False,
         to_upgrade=[],
-        editable=True,
         extras=["c"],
         uninstall_unneeded=False,
         project_root=tmp_path,
@@ -423,7 +310,6 @@ def test_sync_extras(virtualenv_python, testpkgs, tmp_path):
         virtualenv_python,
         upgrade_all=False,
         to_upgrade=[],
-        editable=True,
         extras=["c"],
         uninstall_unneeded=False,
         project_root=tmp_path,


### PR DESCRIPTION
Now that PEP 660 is a thing and is supported by pip and flit at least, make editable install non-optional.

In retrospect, installing in non-editable mode was a bad UX anyway.
