### PR TITLE
Don't show a stack trace when post sync commands fail

### DIFF
--- a/news/91.feature
+++ b/news/91.feature
@@ -1,0 +1,1 @@
+Don't show a stack trace when a post sync commands fails.

--- a/src/pip_deepfreeze/sync.py
+++ b/src/pip_deepfreeze/sync.py
@@ -126,4 +126,8 @@ def sync(
     # run post-sync commands
     for command in post_sync_commands:
         log_info(f"Running post-sync command: {command}")
-        subprocess.run(command, shell=True, check=True)
+        result = subprocess.run(command, shell=True, check=False)
+        if result.returncode != 0:
+            raise SystemExit(
+                f"Post-sync command {command} failed with exit code {result.returncode}"
+            )

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -361,3 +361,21 @@ def test_post_sync_command(virtualenv_python, testpkgs, tmp_path):
         capture_output=True,
     )
     assert res.stdout.endswith("post-sync-cmd-1\npost-sync-cmd-2\n")
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip_deepfreeze",
+            "--python",
+            virtualenv_python,
+            "sync",
+            "--post-sync-command",
+            "notacommand",
+        ],
+        cwd=tmp_path,
+        text=True,
+        check=False,
+        capture_output=True,
+    )
+    assert res.returncode != 0
+    assert "Post-sync command notacommand failed" in res.stderr


### PR DESCRIPTION
Closes #91 