### PR TITLE
Normalize requirement lines in pip_upgrade_project

### DIFF
--- a/news/93.bugfix
+++ b/news/93.bugfix
@@ -1,0 +1,2 @@
+Avoid needlessly reinstalling Direct URL requirements that are not pinned exactly as pip
+freeze does.

--- a/src/pip_deepfreeze/pip.py
+++ b/src/pip_deepfreeze/pip.py
@@ -16,7 +16,14 @@ from .req_file_parser import (
     parse as parse_req_file,
 )
 from .req_parser import get_req_name
-from .utils import check_call, check_output, log_debug, log_info, log_warning
+from .utils import (
+    check_call,
+    check_output,
+    log_debug,
+    log_info,
+    log_warning,
+    normalize_req_line,
+)
 
 
 def pip_upgrade_project(
@@ -33,7 +40,7 @@ def pip_upgrade_project(
     Ideally, this should be a native pip feature but
     - pip has difficulties upgrading direct URL requirements
       https://github.com/pypa/pip/issues/5780, https://github.com/pypa/pip/issues/7678
-      (need to check if the new resolver does the exepected thing).
+      (need to check if the new resolver does the expected thing).
     - We need to pass --upgrade for regular requirements otherwise pip will not attempt
       to install them (requirement already satisfied).
     - Passing --upgrade to pip makes it too slow to my taste (need to check performance
@@ -59,10 +66,10 @@ def pip_upgrade_project(
         if isinstance(req_line, RequirementLine):
             req_name = get_req_name(req_line.requirement)
             assert req_name  # XXX user error instead?
-            constraint_reqs[req_name] = req_line.requirement
+            constraint_reqs[req_name] = normalize_req_line(req_line.requirement)
     # 2. get installed frozen dependencies of project
     installed_reqs = {
-        get_req_name(req_line): req_line
+        get_req_name(req_line): normalize_req_line(req_line)
         for req_line in pip_freeze_dependencies(python, project_root, extras)[0]
     }
     assert all(installed_reqs.keys())  # XXX user error instead?

--- a/src/pip_deepfreeze/utils.py
+++ b/src/pip_deepfreeze/utils.py
@@ -1,4 +1,5 @@
 import contextlib
+import re
 import subprocess
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -116,3 +117,21 @@ def make_project_name_with_extras(
         return project_name
     else:
         return project_name + "[" + ",".join(extras) + "]"
+
+
+_NORMALIZE_REQ_LINE_RE = re.compile(
+    r"^(?P<name>[a-zA-Z0-9-_.]+)(?P<arobas>\s*@\s*)(?P<rest>.*)$"
+)
+
+
+def normalize_req_line(req_line: str) -> str:
+    """Normalize a requirement line so they are comparable.
+
+    This is a little hack because some requirements.txt generator such
+    as pip-requirements-parser dont always generate the exact same
+    output as pip freeze.
+    """
+    mo = _NORMALIZE_REQ_LINE_RE.match(req_line)
+    if not mo:
+        return req_line
+    return mo.group("name") + " @ " + mo.group("rest")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ from pip_deepfreeze.utils import (
     log_notice,
     log_warning,
     make_project_name_with_extras,
+    normalize_req_line,
     open_with_rollback,
 )
 
@@ -132,3 +133,16 @@ def test_comma_split(s, expected):
 )
 def test_make_project_name_with_extras(project_name, extras, expected):
     assert make_project_name_with_extras(project_name, extras) == expected
+
+
+@pytest.mark.parametrize(
+    "req_line, expected",
+    [
+        ("prj", "prj"),
+        ("prj==1.0", "prj==1.0"),
+        ("name @https://g.c/o/p@branch", "name @ https://g.c/o/p@branch"),
+        ("name@https://g.c/o/p@branch", "name @ https://g.c/o/p@branch"),
+    ],
+)
+def test_normalize_req_line(req_line: str, expected: str) -> None:
+    assert normalize_req_line(req_line) == expected


### PR DESCRIPTION
This is to avoid reinstalling requirements that are not pinned exactly as pip freeze does.
This happen when the output of pip-df sync is post-processed by other tools.