### PR TITLE
Use `pip inspect` if the target pip supports it

### DIFF
--- a/news/97.feature
+++ b/news/97.feature
@@ -1,0 +1,2 @@
+Use ``pip inspect`` when the target pip supports it. This allows working in virtual
+environments where ``pkg_resources and thus ``setuptools`` are not installed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies=[
     "httpx",
-    "packaging>=20.4",
+    "packaging>=23",
     "toml",
     "typer[all]>=0.3.2",
     "typing-extensions ; python_version<'3.8'",  # for Protocol, TypedDict

--- a/src/pip_deepfreeze/pip_list_json.py
+++ b/src/pip_deepfreeze/pip_list_json.py
@@ -2,11 +2,9 @@
 """List installed distributions with some of their metadata in json format.
 
 This currently assumes pkg_resources is installed.
-TODO: use importlib.metadata and fallback on pkg_resources if not available.
+In environments without setuptools, we'll use 'pip inspect'.
 
 This script must be python 2 compatible.
-
-This may one day become a native pip feature (https://github.com/pypa/pip/pull/8008).
 """
 
 import json

--- a/src/pip_deepfreeze/tree.py
+++ b/src/pip_deepfreeze/tree.py
@@ -14,6 +14,12 @@ from .utils import make_project_name_with_extras
 NodeKey = Tuple[NormalizedName, Tuple[NormalizedName, ...]]
 
 
+def _req_name_with_extras(req: Requirement) -> str:
+    if req.extras:
+        return f"{req.name}[{','.join(sorted(req.extras))}]"
+    return req.name
+
+
 class Node:
     def __init__(self, req: Requirement, dist: Optional[InstalledDistribution]):
         self.req = req
@@ -36,7 +42,7 @@ class Node:
             BRANCH = "│   "
             TEE = "├── "
             LAST = "└── "
-            typer.echo(f"{''.join(indent)}{node.req}", nl=False)
+            typer.echo(f"{''.join(indent)}{_req_name_with_extras(node.req)}", nl=False)
             if node in seen:
                 typer.secho(" ⬆", dim=True)
                 return

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -25,10 +25,11 @@ def test_sanity_pip_version(virtualenv_python, capsys):
 
 def test_sanity_pkg_resources(virtualenv_python, capsys):
     assert check_env(virtualenv_python)
+    subprocess.check_call([virtualenv_python, "-m", "pip", "install", "-q", "pip<22.2"])
     subprocess.check_call(
         [virtualenv_python, "-m", "pip", "uninstall", "-qy", "setuptools"]
     )
-    # pkg_resources is currently required
+    # pkg_resources is required when `pip inspect` is not available
     assert not check_env(virtualenv_python)
     captured = capsys.readouterr()
     assert "pkg_resources is not available" in captured.err


### PR DESCRIPTION
Thanks to this we can work in environments that don't have `pkg_resources`.

closes #54 
closes #97 