### PR TITLE
Freeze pip legacy build tools if they are dependencies

### DIFF
--- a/news/123.features
+++ b/news/123.features
@@ -1,0 +1,3 @@
+Pin pip, setuptools, wheel and distribute when they are dependencies of the project.
+Before they were not pinned in the ``requirements*.txt`` lock file because they were not
+reported by pip freeze. Now we pin them but never propose to uninstall them.

--- a/src/pip_deepfreeze/pip.py
+++ b/src/pip_deepfreeze/pip.py
@@ -182,7 +182,7 @@ def pip_list(python: str) -> InstalledDistributions:
 
 def pip_freeze(python: str) -> Iterable[str]:
     """Run pip freeze."""
-    cmd = [python, "-m", "pip", "freeze"]
+    cmd = [python, "-m", "pip", "freeze", "--all"]
     return check_output(cmd).splitlines()
 
 

--- a/src/pip_deepfreeze/sync.py
+++ b/src/pip_deepfreeze/sync.py
@@ -94,8 +94,11 @@ def sync(
             for req_line in frozen_reqs:
                 print(req_line, file=f)
     # uninstall unneeded dependencies, if asked to do so
-    if unneeded_reqs:
-        unneeded_req_names = get_req_names(unneeded_reqs)
+    unneeded_req_names = sorted(
+        set(str(s) for s in get_req_names(unneeded_reqs))
+        - set(["pip", "setuptools", "wheel", "distribute"])
+    )
+    if unneeded_req_names:
         unneeded_reqs_str = ",".join(unneeded_req_names)
         prompted = False
         if uninstall_unneeded is None:


### PR DESCRIPTION
Output pip, setuptools, wheel, distribute in frozen reqs if they are (possibly indirect) dependencies of the project.

Never propose to uninstall them.

closes #123 