### PR TITLE
Support `--min-version`, `tool.pip-deepfreeze.min_version`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,6 +298,7 @@ Global options
                                    python environment to work on. Defaults to the
                                    'py' or 'python' executable found in PATH.
      -r, --project-root DIRECTORY  The project root directory.  [default: .]
+     --min-version      VERSION    Minimum version of pip-deepfreeze required.
      --version                     Show the version and exit.
      -v, --verbose
      --install-completion          Install completion for the current shell.

--- a/news/95.feature
+++ b/news/95.feature
@@ -1,0 +1,3 @@
+Declare minimum pip-deepfreeze version in ``pyproject.toml``.
+pip-deepfreeze verifies its version according to `tool.pip-deepfreeze.min_version`,
+so a project can ensure all contributors have the minmum required version.

--- a/src/pip_deepfreeze/__main__.py
+++ b/src/pip_deepfreeze/__main__.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional
 
 import typer
 from packaging.utils import canonicalize_name
+from packaging.version import Version
 
 from .pip import Installer
 from .pyproject_toml import load_pyproject_toml
@@ -173,6 +174,12 @@ def callback(
         resolve_path=True,
         help="The project root directory.",
     ),
+    min_version: Optional[str] = typer.Option(
+        None,
+        "--min-version",
+        metavar="VERSION",
+        help="Minimum version of pip-deepfreeze required.",
+    ),
     version: bool = typer.Option(
         None,
         "--version",
@@ -183,6 +190,14 @@ def callback(
     verbose: bool = typer.Option(False, "--verbose", "-v", show_default=False),
 ) -> None:
     """A simple pip freeze workflow for Python application developers."""
+    if min_version:
+        current_version = importlib.metadata.version("pip-deepfreeze")
+        if Version(current_version) < Version(min_version):
+            log_error(
+                f"pip-deepfreeze {min_version} or later is required. "
+                f"Current version is {current_version}."
+            )
+            raise typer.Exit(1)
     # handle verbosity/quietness
     if verbose:
         increase_verbosity()


### PR DESCRIPTION
closes #95 