### PR TITLE
Always install uv as a dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,12 +73,6 @@ Using `pip <https://pypi.org/project/pip/>`__:
    normally expect in an activated virtualenv), but you can ask it to work within
    another environment using the ``--python`` option.
 
-.. note::
-
-   ``pip-deepfreeze`` has experimental support for the `uv
-   <https://github.com/astral-sh/uv>`_ installer. To use it, install with ``pipx install
-   pip-deepfreeze[uv]`` and run ``pip-df sync --installer=uv``.
-
 Quick start
 -----------
 
@@ -108,6 +102,12 @@ You can then add this ``requirement.txt`` to version control, and other people
 collaborating on the project can install the project and its known good
 dependencies using ``pip-df sync`` (or ``pip install -r requirements.txt -e .``
 in a fresh virtualenv).
+
+.. note::
+
+   ``pip-deepfreeze`` has experimental support for the `uv
+   <https://github.com/astral-sh/uv>`_ installer. To use it, run ``pip-df sync
+   --installer=uv``.
 
 When you add or remove dependencies of your project, run ``pip-df sync`` again
 to update your environment and ``requirements.txt``.

--- a/news/143.feature
+++ b/news/143.feature
@@ -1,0 +1,1 @@
+Always install ``uv`` as a dependency. Consequently, the ``uv`` extra is removed.

--- a/news/95.feature
+++ b/news/95.feature
@@ -1,3 +1,3 @@
 Declare minimum pip-deepfreeze version in ``pyproject.toml``.
-pip-deepfreeze verifies its version according to `tool.pip-deepfreeze.min_version`,
+pip-deepfreeze verifies its version according to ``tool.pip-deepfreeze.min_version``,
 so a project can ensure all contributors have the minmum required version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,16 +27,18 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies=[
     "httpx",
-    "packaging>=23",
-    "pip>=22.2",
-    "tomli ; python_version<'3.11'",
-    "typer[all]>=0.3.2",
+    "packaging >=23",
+    "typer[all] >=0.3.2",
+    # installers
+    "pip >=22.2",
+    "uv",
+    # compat
     "importlib_resources>=1.3 ; python_version<'3.9'",
+    "tomli ; python_version<'3.11'",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-"uv" = ["uv"]
 "test" = ["pytest", "pytest-cov", "pytest-xdist", "virtualenv", "setuptools", "wheel"]
 "mypy" = ["mypy", "types-toml", "types-setuptools"]
 

--- a/src/pip_deepfreeze/__main__.py
+++ b/src/pip_deepfreeze/__main__.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 
 from .pip import Installer
 from .pyproject_toml import load_pyproject_toml
-from .sanity import check_env, get_python_version_info
+from .sanity import check_env
 from .sync import sync as sync_operation
 from .tree import tree as tree_operation
 from .utils import comma_split, increase_verbosity, log_debug, log_error
@@ -82,10 +82,6 @@ def sync(
     update of dependencies to to the latest version that matches
     constraints. Optionally uninstall unneeded dependencies.
     """
-    if installer == Installer.uv and get_python_version_info(ctx.obj.python) < (3, 7):
-        log_error("The 'uv' installer requires Python 3.7 or later.")
-        raise typer.Exit(1)
-
     sync_operation(
         ctx.obj.python,
         upgrade_all,


### PR DESCRIPTION
This is still considered experimental but it works well, and very likely here to stay, so we always install it as a dependency of pip-deepfreeze and remove the uv extra.