### PR TITLE
ci: macos-latest runner don't have python 3.6 and 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,6 @@ jobs:
             python: python
           # macos
           - os: "macos-latest"
-            python-version: "3.6"
-            python: python
-          - os: "macos-latest"
-            python-version: "3.7"
-            python: python
-          - os: "macos-latest"
             python-version: "3.8"
             python: python
           - os: "macos-latest"


### PR DESCRIPTION
Se don't bother, stop testing that. We continue testing on Ubuntu.