### PR TITLE
[FIX] force refreshing of project metadata when using uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies=[
     "typer[all] >=0.3.2",
     # installers
     "pip >=22.2",
-    "uv >=0.1.12",
+    "uv >=0.2.37",
     # compat
     "importlib_resources>=1.3 ; python_version<'3.9'",
     "tomli ; python_version<'3.11'",


### PR DESCRIPTION
I prefer a less surprising default at a very minor cost of recomputing metadata when doing the editable install.

Opinionated work around for https://github.com/astral-sh/uv/issues/5484