### PR TITLE
[WIP] pylock.toml support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies=[
     "httpx",
-    "packaging >=23",
+    "packaging >=26",  # TODO 26.1, hopefully
     "typer >=0.12.1",
     "click >= 8.2",
     # installers

--- a/src/pip_deepfreeze/__main__.py
+++ b/src/pip_deepfreeze/__main__.py
@@ -10,7 +10,7 @@ from packaging.version import Version
 from .pip import Installer, InstallerFlavor
 from .pyproject_toml import load_pyproject_toml
 from .sanity import check_env
-from .sync import sync as sync_operation
+from .sync import LockFormat, lock_and_sync, sync as sync_operation
 from .tree import tree as tree_operation
 from .utils import comma_split, increase_verbosity, log_debug, log_error, log_warning
 
@@ -61,6 +61,10 @@ def sync(
             ),
         ),
     ] = None,
+    lock_format: Annotated[
+        LockFormat,
+        typer.Option(),
+    ] = LockFormat.requirements_txt,
     uninstall_unneeded: Annotated[
         bool | None,
         typer.Option(
@@ -116,7 +120,8 @@ def sync(
 
     Install/reinstall the project. Install/update dependencies to the
     latest allowed version according to pinned dependencies in
-    requirements.txt or constraints in constraints.txt/requirements.txt.in. On demand
+    requirements.txt/pylock.toml or constraints in
+    constraints.txt/requirements.txt.in. On demand
     update of dependencies to to the latest version that matches
     constraints. Optionally uninstall unneeded dependencies.
     """
@@ -124,18 +129,34 @@ def sync(
         log_warning(
             "--build-contraints is deprecated, use --build-constraints instead."
         )
-    sync_operation(
-        Installer.create(flavor=installer, python=ctx.obj.python),
-        ctx.obj.python,
-        upgrade_all,
-        comma_split(to_upgrade),
-        extras=[canonicalize_name(extra) for extra in comma_split(extras)],
-        uninstall_unneeded=uninstall_unneeded,
-        project_root=ctx.obj.project_root,
-        pre_sync_commands=pre_sync_commands or [],
-        post_sync_commands=post_sync_commands or [],
-        build_constraints=build_constraints or build_contraints,
-    )
+    if lock_format == LockFormat.requirements_txt:
+        sync_operation(
+            Installer.create(flavor=installer, python=ctx.obj.python),
+            ctx.obj.python,
+            upgrade_all,
+            comma_split(to_upgrade),
+            extras=[canonicalize_name(extra) for extra in comma_split(extras)],
+            uninstall_unneeded=uninstall_unneeded,
+            project_root=ctx.obj.project_root,
+            pre_sync_commands=pre_sync_commands or [],
+            post_sync_commands=post_sync_commands or [],
+            build_constraints=build_constraints or build_contraints,
+        )
+    elif lock_format == LockFormat.pylock_toml:
+        lock_and_sync(
+            Installer.create(flavor=installer, python=ctx.obj.python),
+            ctx.obj.python,
+            upgrade_all,
+            comma_split(to_upgrade),
+            extras=[canonicalize_name(extra) for extra in comma_split(extras)],
+            uninstall_unneeded=uninstall_unneeded,
+            project_root=ctx.obj.project_root,
+            pre_sync_commands=pre_sync_commands or [],
+            post_sync_commands=post_sync_commands or [],
+            build_constraints=build_constraints or build_contraints,
+        )
+    else:
+        raise NotImplementedError
 
 
 @app.command()

--- a/src/pip_deepfreeze/env-info-json.py
+++ b/src/pip_deepfreeze/env-info-json.py
@@ -27,6 +27,7 @@ except ImportError:
 
 try:
     warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+    warnings.filterwarnings(action="ignore", category=UserWarning)
     import pkg_resources  # noqa
     warnings.resetwarnings()
 except ImportError:

--- a/src/pip_deepfreeze/pip.py
+++ b/src/pip_deepfreeze/pip.py
@@ -92,6 +92,25 @@ class Installer(ABC):
         """Whether the installer caches metadata preparation results."""
         ...
 
+    @abstractmethod
+    def lock(
+        self,
+        *,
+        python: str,
+        project_root: Path,
+        constraints: Path | None = None,
+        build_constraints: Path | None = None,
+    ) -> None: ...
+
+    @abstractmethod
+    def sync(
+        self,
+        *,
+        python: str,
+        project_root: Path,
+        extras: Sequence[NormalizedName] | None,
+    ) -> None: ...
+
     @classmethod
     def create(cls, flavor: InstallerFlavor, python: str) -> "Installer":
         if flavor == InstallerFlavor.pip:
@@ -125,6 +144,27 @@ class PipInstaller(Installer):
     def has_metadata_cache(self) -> bool:
         return False
 
+    def lock(
+        self,
+        *,
+        python: str,
+        project_root: Path,
+        constraints: Path | None = None,
+        build_constraints: Path | None = None,
+    ) -> None:
+        # TODO use pip lock -e .[extras] -c constraints --build-constraints
+        # build_constraints
+        raise NotImplementedError
+
+    def sync(
+        self,
+        *,
+        python: str,
+        project_root: Path,
+        extras: Sequence[NormalizedName] | None,
+    ) -> None:
+        raise NotImplementedError
+
 
 class UvpipInstaller(Installer):
     def install_cmd(
@@ -148,6 +188,7 @@ class UvpipInstaller(Installer):
         )
         # https://github.com/astral-sh/uv/issues/5484
         cmd.append(f"--refresh-package={project_name}")
+        cmd.append("--strict")
         return cmd
 
     def uninstall_cmd(self, python: str) -> list[str]:
@@ -158,6 +199,72 @@ class UvpipInstaller(Installer):
 
     def has_metadata_cache(self) -> bool:
         return True
+
+    def lock(
+        self,
+        *,
+        python: str,
+        project_root: Path,
+        constraints: Path | None = None,
+        build_constraints: Path | None = None,
+    ) -> None:
+        """Lock project to pylock.toml."""
+        pylock_tmp = get_temp_path_in_dir(project_root, "pylock.", suffix=".df.toml")
+        pylock_tmp.unlink()  # because it's empty and uv will try to parse it
+        cmd = [
+            *get_uv_cmd(),
+            "pip",
+            "compile",
+            "--python",
+            python,
+            "--format",
+            "pylock.toml",
+            "--output-file",
+            str(pylock_tmp),
+            "--custom-compile-command",
+            "pip-deepfreeze sync",
+            "--all-extras",
+            # XXX --all-groups
+        ]
+        if constraints:
+            cmd.extend(["--constraints", str(constraints)])
+        if build_constraints:
+            cmd.extend(["--build-constraints", str(build_constraints)])
+        cmd.append("pyproject.toml")
+        log_debug(f"Running {shlex.join(cmd)}")
+        check_output(
+            cmd, cwd=project_root
+        )  # use check_output because https://github.com/astral-sh/uv/issues/15309
+        pylock_tmp.rename(project_root / "pylock.toml")
+
+    def sync(
+        self,
+        *,
+        python: str,
+        project_root: Path,
+        extras: Sequence[NormalizedName] | None,
+    ) -> None:
+        project_name = get_project_name(python, project_root)
+        sync_cmd = [
+            *get_uv_cmd(),
+            "--preview-feature=pylock",
+            "pip",
+            "sync",
+            "--python",
+            python,
+            "pylock.toml",
+        ]
+        if extras:
+            for extra in extras:
+                sync_cmd.extend(("--extra", extra))
+        log_debug(f"Running {shlex.join(sync_cmd)}")
+        check_call(sync_cmd, cwd=project_root)
+        editable_install_cmd = [
+            *self.editable_install_cmd(python, project_root, project_name, extras),
+            "--exact",  # --uninstall-unneeded always on
+        ]
+        log_debug(f"Running {shlex.join(editable_install_cmd)}")
+        check_call(editable_install_cmd, cwd=project_root)
 
 
 def pip_upgrade_project(

--- a/src/pip_deepfreeze/pylock.py
+++ b/src/pip_deepfreeze/pylock.py
@@ -1,0 +1,89 @@
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+from packaging.pylock import (
+    Package,
+    PackageArchive,
+    PackageDirectory,
+    PackageSdist,
+    PackageVcs,
+    PackageWheel,
+    Pylock,
+)
+
+from .compat import tomllib
+from .python_env import get_python_environment_and_tags
+
+
+def _dist_url(dist: PackageArchive | PackageVcs) -> str:
+    if dist.path:
+        return Path(dist.path).absolute().as_uri()
+    elif dist.url:
+        return dist.url
+    else:
+        raise ValueError("Distribution must have either a path or URL.")
+
+
+def _package_vcs_url(dist: PackageVcs) -> str:
+    url = f"{dist.type}+{_dist_url(dist)}@{dist.commit_id}"
+    if dist.subdirectory:
+        url += f"#subdirectory={dist.subdirectory}"
+    return url
+
+
+def _pylock_packages_to_requirements(
+    packages: Iterable[
+        tuple[
+            Package,
+            PackageArchive
+            | PackageSdist
+            | PackageWheel
+            | PackageVcs
+            | PackageDirectory,
+        ]
+    ],
+) -> Iterator[str]:
+    for package, package_dist in packages:
+        if isinstance(package_dist, PackageWheel):
+            yield f"{package.name}=={package.version}"
+        elif isinstance(package_dist, PackageSdist):
+            yield f"{package.name}=={package.version}"
+        elif isinstance(package_dist, PackageVcs):
+            yield f"{package.name} @ {_package_vcs_url(package_dist)}"
+        elif isinstance(package_dist, PackageArchive):
+            yield f"{package.name} @ {_dist_url(package_dist)}"
+        elif isinstance(package_dist, PackageDirectory):
+            yield f"{'-e ' if package_dist.editable else ''}{package_dist.path}"
+        else:
+            raise NotImplementedError(
+                f"Unsupported package distribution type: {type(package_dist)}"
+            )
+
+
+def pylock_to_requirements_txt(
+    python: str,
+    pylock_path: Path,
+    requirements_txt_path: Path,
+) -> None:
+    """Convert a pylock.toml file to a requirements.txt string.
+
+    This selects for all extras and dependency groups.
+    """
+    if not pylock_path.is_file():
+        requirements = ""
+    else:
+        environment, tags = get_python_environment_and_tags(python)
+        pylock = Pylock.from_dict(
+            tomllib.loads(pylock_path.read_text(encoding="utf-8"))
+        )
+        requirements = "\n".join(
+            _pylock_packages_to_requirements(
+                pylock.select(
+                    environment=environment,
+                    tags=tags,
+                    extras=pylock.extras,
+                    dependency_groups=pylock.dependency_groups,
+                )
+            )
+        )
+    requirements_txt_path.write_text(requirements)

--- a/src/pip_deepfreeze/python_env.py
+++ b/src/pip_deepfreeze/python_env.py
@@ -1,0 +1,54 @@
+import json
+import os
+from functools import lru_cache
+from tempfile import TemporaryDirectory
+from typing import cast
+
+from packaging.markers import Environment
+from packaging.tags import Tag, parse_tag
+
+from .sanity import get_pip_command
+from .utils import check_call, check_output
+
+_SCRIPT = """\
+import json
+import sys
+
+from packaging import markers, tags
+
+json.dump(
+    {
+        "environment": markers.default_environment(),
+        "tags": [str(tag) for tag in tags.sys_tags()],
+    },
+    sys.stdout,
+)
+"""
+
+
+@lru_cache
+def get_python_environment_and_tags(python: str) -> tuple[Environment, list[Tag]]:
+    """Get target python Environment and tags.
+
+    Run in a subprocess where packaging is installed.
+    """
+    with TemporaryDirectory() as packaging_install_dir:
+        # first install packaging
+        check_call(
+            [
+                *get_pip_command(python),
+                "-q",
+                "install",
+                "--target",
+                packaging_install_dir,
+                "packaging",
+            ]
+        )
+        res = check_output(
+            [python, "-c", _SCRIPT],
+            env=dict(os.environ, PYTHONPATH=packaging_install_dir),
+        )
+        res = json.loads(res)
+        return cast("Environment", res["environment"]), [
+            next(iter(parse_tag(tag))) for tag in res["tags"]
+        ]

--- a/src/pip_deepfreeze/sync.py
+++ b/src/pip_deepfreeze/sync.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from enum import Enum
 from pathlib import Path
 
 import typer
@@ -12,6 +13,7 @@ from .pip import (
     pip_upgrade_project,
 )
 from .project_name import get_project_name
+from .pylock import pylock_to_requirements_txt
 from .req_file_parser import OptionsLine, parse as parse_req_file
 from .req_merge import prepare_frozen_reqs_for_upgrade
 from .req_parser import get_req_name, get_req_names
@@ -20,6 +22,7 @@ from .utils import (
     get_temp_path_in_dir,
     log_debug,
     log_info,
+    log_warning,
     make_frozen_requirements_path,
     make_frozen_requirements_paths,
     make_project_name_with_extras,
@@ -27,6 +30,11 @@ from .utils import (
     open_with_rollback,
     run_commands,
 )
+
+
+class LockFormat(str, Enum):
+    requirements_txt = "requirements.txt"
+    pylock_toml = "pylock.toml"
 
 
 def _req_line_sort_key(req_line: str) -> str:
@@ -153,5 +161,80 @@ def sync(
     # fixup VCS direct_url.json (see fixup-vcs-direct-urls.py for details on why)
     if not installer.has_metadata_cache():
         pip_fixup_vcs_direct_urls(python)
+    # run post-sync commands
+    run_commands(post_sync_commands, project_root, "post-sync")
+
+
+def lock_and_sync(
+    installer: Installer,
+    python: str,
+    upgrade_all: bool,
+    to_upgrade: list[str],
+    extras: list[NormalizedName],
+    uninstall_unneeded: bool | None,
+    project_root: Path,
+    pre_sync_commands: Sequence[str] = (),
+    post_sync_commands: Sequence[str] = (),
+    build_constraints: Path | None = None,
+) -> None:
+    # run pre-sync commands
+    run_commands(pre_sync_commands, project_root, "pre-sync")
+    # compute some paths and prepare temporary files
+    constraints_path = _constraints_path(project_root)
+    pylock_path = project_root / "pylock.toml"
+    pylock_as_requirements_path = get_temp_path_in_dir(
+        dir=project_root, prefix="reqirements-from-pylock.", suffix=".txt.df"
+    )
+    merged_constraints_path = get_temp_path_in_dir(
+        dir=project_root, prefix="requirements.", suffix=".txt.df"
+    )
+    if pylock_path.is_file():
+        # convert pylock to requirements.txt so our merge algo can be reused
+        pylock_to_requirements_txt(python, pylock_path, pylock_as_requirements_path)
+        frozen_req_paths = [pylock_as_requirements_path]
+        frozen_req_paths_to_remove = None
+    else:
+        # if no pylock.toml, use existing requirements.txt
+        frozen_req_paths = list(make_frozen_requirements_paths(project_root, extras))
+        if frozen_req_paths:
+            log_info(f"Using {frozen_req_paths} as pylock.toml seed")
+        frozen_req_paths_to_remove = frozen_req_paths
+    # merge lock file and constraints as a new requirements.txt format constraints file
+    with merged_constraints_path.open(mode="w", encoding="utf-8") as constraints:
+        for req_line in prepare_frozen_reqs_for_upgrade(
+            frozen_req_paths,
+            constraints_path,
+            upgrade_all,
+            to_upgrade,
+        ):
+            if isinstance(req_line, OptionsLine):
+                log_warning(f"Ignored option line {req_line}")
+            else:
+                print(req_line.raw_line, file=constraints)
+    # lock
+    installer.lock(
+        python=python,
+        project_root=project_root,
+        constraints=merged_constraints_path,
+        build_constraints=build_constraints,
+    )
+    # we have a pylock.toml, remove legacy requirements*.txt
+    if frozen_req_paths_to_remove:
+        readable_frozen_req_paths_to_remove = ", ".join(
+            str(p.relative_to(Path.cwd())) for p in frozen_req_paths_to_remove
+        )
+        log_warning(
+            f"Removing {readable_frozen_req_paths_to_remove} "
+            "as we now have a pylock.toml"
+        )
+        for p in frozen_req_paths_to_remove:
+            p.unlink()
+    # sync
+    if uninstall_unneeded is not True:
+        log_warning(
+            "--no-uninstall-unneeded option ignored, "
+            "unneeded dependencies will be uninstalled unconditionally"
+        )
+    installer.sync(python=python, project_root=project_root, extras=extras)
     # run post-sync commands
     run_commands(post_sync_commands, project_root, "post-sync")

--- a/src/pip_deepfreeze/utils.py
+++ b/src/pip_deepfreeze/utils.py
@@ -5,6 +5,7 @@ import shlex
 import subprocess
 import tempfile
 from collections.abc import Iterable, Iterator, Sequence
+from functools import partial
 from pathlib import Path
 from subprocess import CalledProcessError
 from typing import IO, Any
@@ -158,7 +159,7 @@ def get_temp_path_in_dir(dir: Path, prefix: str, suffix: str) -> Path:
         dir=dir, prefix=prefix, suffix=suffix, delete=False
     ) as tf:
         path = Path(tf.name)
-        atexit.register(path.unlink)
+        atexit.register(partial(path.unlink, missing_ok=True))
         return path
 
 


### PR DESCRIPTION
- [ ] needs https://github.com/pypa/packaging/pull/1092
- [ ] ~add extras marker in pylock.toml, in a way that will nicely extend to dependency groups afterwards~ Not really feasible without a resolver so that will have to wait from uv or pip support. In the meantime pylock.toml will lock all extras and dependency groups and sync will install only requested extras and dependency groups.
- [x] sync after lock
- [ ] support --uninstall-unneeded?
- [ ] tests
